### PR TITLE
Preserve oldest input stamp in concatenated cloud

### DIFF
--- a/src/pointcloud_concat_node.cpp
+++ b/src/pointcloud_concat_node.cpp
@@ -170,7 +170,21 @@ void PointCloudConcatNode::update() {
 
 void PointCloudConcatNode::publishPointcloud(sensor_msgs::msg::PointCloud2 cloud)
 {
-    cloud.header.stamp = rclcpp::Clock().now();
+    // Use the oldest stamp among received input clouds to keep TF lookups safe (past side).
+    // Overwriting with now() pushes the stamp into the future relative to the actual capture
+    // time and causes "extrapolation into the future" errors in downstream TF consumers.
+    rclcpp::Time oldest;
+    bool have_any = false;
+    auto consider = [&](const sensor_msgs::msg::PointCloud2 & in, bool received) {
+        if (!received) return;
+        rclcpp::Time t(in.header.stamp);
+        if (!have_any || t < oldest) { oldest = t; have_any = true; }
+    };
+    consider(cloud_in1, cloud_in1_received);
+    consider(cloud_in2, cloud_in2_received);
+    consider(cloud_in3, cloud_in3_received);
+    consider(cloud_in4, cloud_in4_received);
+    cloud.header.stamp = have_any ? oldest : this->get_clock()->now();
     pub_cloud_out->publish(cloud);
 }
 


### PR DESCRIPTION
## Summary

`publishPointcloud()` で出力点群の `header.stamp` を `rclcpp::Clock().now()` で上書きしているため、入力 LiDAR の取得時刻が失われ、下流の Nav2 で TF lookup "extrapolation into the future" エラーが発生していた。入力 cloud のうち最古の stamp を採用するように変更し、TF lookup が常に安全側（過去側）になるようにする。
- fix #3

## Detail

- `publishPointcloud()` の `cloud.header.stamp = rclcpp::Clock().now();` を削除
- 受信済み入力 cloud のうち最古の `header.stamp` を出力 stamp として採用
- どの cloud も受信していない場合のフォールバックは `this->get_clock()->now()` に変更（`use_sim_time` に追従させるため）

## Impact

- 出力点群の stamp が真の取得時刻に近づくため、下流ノードでの TF lookup が安全側に倒れる
- stamp の見た目の遅延は増える（実機計測で `/lidar/concat` の stamp 遅延が +14 ms → +148 ms）が、データ自体の遅延は変わらない（従来は stamp が嘘をついていただけ）
- これまで concat 出力の stamp を「ほぼ現在時刻」として参照していた consumer がもしあれば、stamp 値が変わる影響を受ける

## Test

- [x] ビルドが通った
- [ ] gazebo環境で動作した
- [x] 実機環境で動作した
  - 実機計測で `/lidar/concat` の stamp 遅延が +14 ms → +148 ms に変化し、上流 livox raw の +103 ms 遅延を正しく反映することを確認
  - Nav2 local_costmap の `TF Exception: extrapolation into the future` エラーが Nav2 起動後 100秒以上にわたり発生しないことを確認

## Attention

- 出力 stamp の値が変わるため、下流ノードでの TF キャッシュ容量に注意（既定 10秒なら十分）
- 4台の Livox のうち1台でも受信が間欠的に遅れると、出力 stamp がその古い stamp に律速される。Cloud 受信欠落そのものは別問題として残る